### PR TITLE
Government Timelapse Maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.1.1] - 2023-08-26
+
+### Fixed
+
+- Missing Government name on Government Detail timelapse maps for some pages that group related, sequential governments.
+
 ## [1.1.0] - 2023-07-01
 
 ### Added
@@ -87,6 +93,7 @@
 
 - Public release of the Local Geohistory Project: Application repository.
 
+[1.1.1]: https://github.com/markconnellypro/local-geohistory-project/compare/v1.1.0...v1.1.1
 [1.1.0]: https://github.com/markconnellypro/local-geohistory-project/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/markconnellypro/local-geohistory-project/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/markconnellypro/local-geohistory-project/compare/v1.0.0...v1.0.1

--- a/src/app/Views/government_end.php
+++ b/src/app/Views/government_end.php
@@ -119,14 +119,15 @@ function toTimeLine() {
   				if (item.eventstatus == 'add' || item.eventstatus == 'name' || item.eventstatus == 'remove' ) {
   					if (!shapeTime.hasOwnProperty(item.eventsortdate)) {
   						shapeTime[item.eventsortdate] = {};
-              shapeTimeText[item.eventsortdate] = item.eventtextsortdate;
+                        shapeTimeText[item.eventsortdate] = item.eventtextsortdate;
   					}
   					if (!shapeNameText.hasOwnProperty(item.eventsortdate)) {
-              shapeNameText[item.eventsortdate] = '';
-  					} else if (item.eventgovernmentlong && shapeNameText[item.eventsortdate] != item.eventgovernmentlong) {
-              shapeNameText[item.eventsortdate] = item.eventgovernmentlong;
-              shapeNameCount++;
-            }
+                        shapeNameText[item.eventsortdate] = '';
+  					}
+                    if (item.eventgovernmentlong && shapeNameText[item.eventsortdate] != item.eventgovernmentlong) {
+                        shapeNameText[item.eventsortdate] = item.eventgovernmentlong;
+                        shapeNameCount++;
+                    }
   					shapeTime[item.eventsortdate][featureIndex] = item.eventstatus;
   				}
   			} catch (err1) {


### PR DESCRIPTION
In some cases, governments are grouped together when they are related and sequential. For example, if a government changes its name or changes its type (e.g., borough, city, township), it often makes sense to group information together about these various iterations on one page instead of multiple.

When this grouping happens, the timelapse maps should show the name of the government as of the Event Date. This patch fixes certain situations where this was not occurring.